### PR TITLE
Added return type to satisfy PHP 8.4

### DIFF
--- a/src/ArrayWrapper.php
+++ b/src/ArrayWrapper.php
@@ -95,7 +95,7 @@ class ArrayWrapper implements \ArrayAccess
 		unset($this->data[$offset]);
 	}
 
-	public function offsetGet($offset)
+	public function offsetGet($offset) : mixed
 	{
 		return $this->data[$offset] ?? null;
 	}


### PR DESCRIPTION
PHP 8.4 complained about the return type of offsetGet not matching the interface ArrayAccess.